### PR TITLE
#1 - Fix Typo in Documentation: "Programm" Corrected to "Program"

### DIFF
--- a/README
+++ b/README
@@ -39,7 +39,7 @@ Additionally you need some external tools (exemplarily for Ubuntu):
 
 -------------------------------------------------------------------
 
-For a detailed explanation of the programm, its usage, etc., please
+For a detailed explanation of the program, its usage, etc., please
 refer to the high level documentation doc/documentation_HL.pdf
 (esp. sections 4-6, for starters).
 


### PR DESCRIPTION
Issue No. #1 

This pull request addresses a minor typo in the documentation where the word **"programm"** was incorrectly used instead of the correct spelling, **"program."**

**Changes made:**
- Updated the documentation to replace "programm" with "program" in the sentence:
  - **Before:** "For a detailed explanation of the programm, its usage, etc."
  - **After:** "For a detailed explanation of the program, its usage, etc."

This correction enhances the readability and professionalism of the documentation. No functional code changes were made, only a textual correction in the documentation.

Thank you for considering this update! If there are any further suggestions or edits needed, please let me know.